### PR TITLE
Add `esli` from the product name "G30Es-Li"

### DIFF
--- a/cspell/.cspell.json
+++ b/cspell/.cspell.json
@@ -183,6 +183,7 @@
         "endl",
         "enduml",
         "Englewood",
+        "esli",
         "Esteve",
         "eulerangle",
         "eval",


### PR DESCRIPTION
The product webpage of  "G30Es-Li" <https://www.yamaha-motor.co.jp/golfcar/lineup/g30es-li/>