### PR TITLE
Add the word `pyaw` used in motion_velocity_optimizer_utils.cpp

### DIFF
--- a/cspell/.cspell.json
+++ b/cspell/.cspell.json
@@ -480,6 +480,7 @@
         "pugi",
         "pugixml",
         "pushable",
+        "pyaw",
         "pycache",
         "pycodestyle",
         "pydevproject",


### PR DESCRIPTION
The word is used as `std::vector<double> px, py, pz, pyaw, tlx, taz, alx, aaz;`.