### PR TITLE
Add `noreport` into the dictionary

### DIFF
--- a/cspell/.cspell.json
+++ b/cspell/.cspell.json
@@ -421,6 +421,7 @@
         "noninteractive",
         "nonzeros",
         "noqa",
+        "noreport",
         "nowrap",
         "nsecs",
         "NSID",


### PR DESCRIPTION
An option of `tree` command.

> $ man tree
> ..snip..
> --noreport
>   Omits printing of the file and directory report at the end of the tree listing.