### PR TITLE
Add unrectify for image geometry

### DIFF
--- a/cspell/.cspell.json
+++ b/cspell/.cspell.json
@@ -843,6 +843,7 @@
         "undeclare",
         "unimoji",
         "unittests",
+        "unrectify",
         "URDF",
         "Uref",
         "usermod",


### PR DESCRIPTION
https://github.com/ros-perception/vision_opencv/blob/906d326c146bd1c6fbccc4cd1268253890ac6e1c/image_geometry/include/image_geometry/pinhole_camera_model.h#L121
image_geometryの関数群に含まれるunrectifyを追加しました。