### PR TITLE
Add numpy function name `arange`

### DIFF
--- a/cspell/.cspell.json
+++ b/cspell/.cspell.json
@@ -22,6 +22,7 @@
         "reports*/**"
     ],
     "words": [
+        "arange",
         "aarch",
         "abstractmethod",
         "AccCmd",

--- a/cspell/.cspell.json
+++ b/cspell/.cspell.json
@@ -22,7 +22,6 @@
         "reports*/**"
     ],
     "words": [
-        "arange",
         "aarch",
         "abstractmethod",
         "AccCmd",
@@ -39,6 +38,7 @@
         "angvel",
         "antialiasing",
         "antiquewhite",
+        "arange",
         "arclength",
         "argmax",
         "argmin",


### PR DESCRIPTION
I'll leave it to you whether to add this or not because we often misspell `arrange` as `arange`.