### PR TITLE
Add a CUDA-related word `callstr`

### DIFF
--- a/cspell/.cspell.json
+++ b/cspell/.cspell.json
@@ -101,6 +101,7 @@
         "Caliskan",
         "callees",
         "calloc",
+        "callstr",
         "canlib",
         "carcolor",
         "cassert",


### PR DESCRIPTION
For example, can be found in <https://github.com/NVIDIA/TensorRT/blob/master/samples/opensource/sampleNMT/cudaError.h>.