### PR TITLE
add words for ntp_monitor

### DIFF
--- a/cspell/.cspell.json
+++ b/cspell/.cspell.json
@@ -119,6 +119,8 @@
         "chdir",
         "Chiyu",
         "chrono",
+        "chrony",
+        "chronyc",
         "classmethod",
         "clothoid",
         "cmake",


### PR DESCRIPTION
対応内容
ntp_monitorのコマンド変更に伴い、以下の単語を追加
  chrony
  chronyc
