### PR TITLE
Ignore *.pcd from checking

### DIFF
--- a/cspell/.cspell.json
+++ b/cspell/.cspell.json
@@ -19,7 +19,8 @@
         "install/**",
         "log/**",
         "public/**",
-        "reports*/**"
+        "reports*/**",
+        "**/*.pcd"
     ],
     "words": [
         "aarch",

--- a/cspell/.cspell.json
+++ b/cspell/.cspell.json
@@ -9,6 +9,7 @@
         }
     ],
     "ignorePaths": [
+        "**/*.pcd",
         "**/.mypy_cache/**",
         "**/__pycache__/**",
         ".git/**",
@@ -19,8 +20,7 @@
         "install/**",
         "log/**",
         "public/**",
-        "reports*/**",
-        "**/*.pcd"
+        "reports*/**"
     ],
     "words": [
         "aarch",


### PR DESCRIPTION
Checking `*.pcd` produces a lot of false positives.