### PR TITLE
Ignore package-lock.json from checking

### DIFF
--- a/cspell/.cspell.json
+++ b/cspell/.cspell.json
@@ -19,6 +19,7 @@
         "external/**",
         "install/**",
         "log/**",
+        "package-lock.json",
         "public/**",
         "reports*/**"
     ],


### PR DESCRIPTION
Checking package-lock.json produces a lot of false positives.