### PR TITLE
Use dictionary file

### DIFF
--- a/cspell/.cspell.json
+++ b/cspell/.cspell.json
@@ -35,12 +35,6 @@
     "flagWords": [
         "planing"
     ],
-    "dictionaries": [
-        "autoware"
-    ],
-    "dictionaryDefinitions": [
-        {"name": "autoware", "path": "./dict/autoware.txt"}
-    ],
     "words": [
         "aarch",
         "abspath",

--- a/cspell/.cspell.json
+++ b/cspell/.cspell.json
@@ -35,6 +35,12 @@
     "flagWords": [
         "planing"
     ],
+    "dictionaries": [
+        "autoware"
+    ],
+    "dictionaryDefinitions": [
+        {"name": "autoware", "path": "./dict/autoware.txt"}
+    ],
     "words": [
         "aarch",
         "abspath",
@@ -79,8 +85,6 @@
         "autorepeat",
         "autoscale",
         "autoupdate",
-        "autoware",
-        "autoware's",
         "AWAPI",
         "AWIV",
         "Axisd",

--- a/cspell/dict/autoware.txt
+++ b/cspell/dict/autoware.txt
@@ -1,0 +1,2 @@
+autoware
+autoware's


### PR DESCRIPTION
Signed-off-by: Takagi, Isamu <isamu.takagi@tier4.jp>

別途辞書ファイル定義して読み込めるようです。現状だとwordsに人名や技術用語、頻出変数名などが全部入っているので分割して整理するのはどうでしょうか？　辞書読み込みの設定が消されてしまっているのでこのコミット(854999c)の差分を見てください。
