### PR TITLE
add microstrain

### DIFF
--- a/cspell/.cspell.json
+++ b/cspell/.cspell.json
@@ -617,6 +617,7 @@
         "meshgrid",
         "metainfo",
         "MGRS",
+        "microstrain",
         "midnightblue",
         "Mihelich",
         "milee",
@@ -1140,7 +1141,6 @@
         "zmqpp",
         "zorder",
         "zstd",
-        "zsync",
-        "microstrain"
+        "zsync"
     ]
 }

--- a/cspell/.cspell.json
+++ b/cspell/.cspell.json
@@ -1140,6 +1140,7 @@
         "zmqpp",
         "zorder",
         "zstd",
-        "zsync"
+        "zsync",
+        "microstrain"
     ]
 }


### PR DESCRIPTION
microstrain:  it is usually called as sensor name in TierIV.
https://www.microstrain.com/