### PR TITLE
Add ignoreRegExpList

### DIFF
--- a/cspell/.cspell.json
+++ b/cspell/.cspell.json
@@ -10,6 +10,28 @@
     ],
     "overrides": [
         {
+            "filename": "**/{*.hpp,*.cpp}",
+            "ignoreRegExpList": [
+                "TODO\\(.+\\)"
+            ]
+        },
+        {
+            "filename": "**/*.md",
+            "ignoreRegExpList": [
+                "\\(Contribution by .+?\\)",
+                "\\]\\(#.+?\\)",
+                "^\\| GPU  Name.+$",
+                "^gdown .+$"
+            ]
+        },
+        {
+            "filename": "**/*.rst",
+            "ignoreRegExpList": [
+                "^.*Merge branch.+$",
+                "^.*Contributors:.+$"
+            ]
+        },
+        {
             "filename": "**/*.svg",
             "ignoreRegExpList": [
                 "etag=&quot;[a-zA-Z0-9 +-/_]+&quot;",


### PR DESCRIPTION
Ignore person's names and misc. For example:

.hpp, .cpp
- `TODO(John Smith)`

.md
- `(Contribution by John Smith)`
- `See [here](#acquirepositionaction)`
- `| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |`
- `gdown something-odd-hash-code or URL`

.rst
- `Merge branch 'master' into branch-name`
- `Contributors: John Smith, Foo Bar`