### PR TITLE
added "bagkeeper"

### DIFF
--- a/cspell/.cspell.json
+++ b/cspell/.cspell.json
@@ -124,6 +124,7 @@
         "Axisf",
         "Azumi",
         "bagfile",
+        "bagkeeper",
         "bagpacker",
         "baseclass",
         "basecoords",


### PR DESCRIPTION
Added a word "bagkeeper " for a new ROS2 node name for TierIV internal use.