### PR TITLE
Add the word CSTO

### DIFF
--- a/cspell/.cspell.json
+++ b/cspell/.cspell.json
@@ -1245,6 +1245,7 @@
         "zmqpp",
         "zorder",
         "zstd",
-        "zsync"
+        "zsync",
+        "CSTO"
     ]
 }


### PR DESCRIPTION
I added the word "CSTO", which mean "Chief Safety Technology Officer".
Please approve this if no problem.