### PR TITLE
Ignore Google Drive hashes in CMakeLists.txt

### DIFF
--- a/cspell/.cspell.json
+++ b/cspell/.cspell.json
@@ -26,6 +26,12 @@
             ]
         },
         {
+            "filename": "**/*.txt",
+            "ignoreRegExpList": [
+                "download\\(.+\\)"
+            ]
+        },
+        {
             "filename": "**/*.rst",
             "ignoreRegExpList": [
                 "^.*Merge branch.+$",


### PR DESCRIPTION
Ignore Google Drive hashes in CMakeLists.txt.

For example:

```
  download(foo.pt abcdefg)
  download(bar.onnx abcdefg)
```