### PR TITLE
Ignore abbreviated text in SVG files

### DIFF
--- a/cspell/.cspell.json
+++ b/cspell/.cspell.json
@@ -45,7 +45,9 @@
                 "filter=\"[a-zA-Z0-9 +-/_#()]+\"",
                 "id=\"[a-zA-Z0-9 +-/_]+\"",
                 "id=&quot;[a-zA-Z0-9 +-/_]+&quot;",
-                "name=&quot;[a-zA-Z0-9 +-/_]+&quot;"
+                "name=&quot;[a-zA-Z0-9 +-/_]+&quot;",
+                "<text .*?>.*?\\.\\.\\.</text>",
+                "^.*?\\.\\.\\.(</text>)?$"
             ]
         }
     ],


### PR DESCRIPTION
For example:
- `Vehicl...\n`
- `text-anchor="middle">maximum stopping distance consid...</text>\n`