### PR TITLE
Ignore author's name in galaxy.yml

### DIFF
--- a/cspell/.cspell.json
+++ b/cspell/.cspell.json
@@ -90,6 +90,12 @@
             ]
         },
         {
+            "filename": "**/galaxy.yml",
+            "ignoreRegExpList": [
+                "- .+<.+@.+>$"
+            ]
+        },
+        {
             "filename": "**/package.xml",
             "ignoreRegExpList": [
                 "<author.*?</author>",


### PR DESCRIPTION
Please let me know if there is a better way. :pray: 

https://github.com/autowarefoundation/autoware/blob/483434300c48bf62077782912eee9f8e58d86d32/ansible/galaxy.yml
https://github.com/autowarefoundation/autoware/runs/4724096797?check_suite_focus=true#step:3:70