### PR TITLE
Add a product name

### DIFF
--- a/cspell/.cspell.json
+++ b/cspell/.cspell.json
@@ -131,7 +131,6 @@
         "planing"
     ],
     "words": [
-        "pilotauto",
         "aarch",
         "abspath",
         "abstractmethod",
@@ -870,6 +869,7 @@
         "peachpuff",
         "Peucker",
         "Philipp",
+        "pilotauto",
         "pinv",
         "pipefail",
         "pipx",

--- a/cspell/.cspell.json
+++ b/cspell/.cspell.json
@@ -131,6 +131,7 @@
         "planing"
     ],
     "words": [
+        "pilotauto",
         "aarch",
         "abspath",
         "abstractmethod",


### PR DESCRIPTION
Sometimes we use `pilotauto` instead of `pilot.auto`.