### PR TITLE
Ignore `uses: ` in GitHub Actions' workflow files

### DIFF
--- a/cspell/.cspell.json
+++ b/cspell/.cspell.json
@@ -84,6 +84,7 @@
         {
             "filename": "**/*.yaml",
             "ignoreRegExpList": [
+                "uses: .+$",
                 "author: .+$",
                 "git_user: .+$",
                 "git_email: .+$"


### PR DESCRIPTION
https://github.com/autowarefoundation/autoware-github-actions/runs/4961105288?check_suite_focus=true

I've checked it locally.