### PR TITLE
Add ignore patterns for sync-files.yaml

### DIFF
--- a/cspell/.cspell.json
+++ b/cspell/.cspell.json
@@ -95,6 +95,14 @@
                 "<author.*?</author>",
                 "<maintainer.*?</maintainer>"
             ]
+        },
+        {
+            "filename": "**/sync-files.yaml",
+            "ignoreRegExpList": [
+                "repository: .*",
+                "source: .*",
+                "dest: .*"
+            ]
         }
     ],
     "ignorePaths": [


### PR DESCRIPTION
https://github.com/autowarefoundation/autoware-github-actions/runs/4961105288?check_suite_focus=true

This is the format I designed. The specification is written [here](https://github.com/autowarefoundation/autoware-github-actions/blob/1f62cc13548aec50b1a333287ab5981fb4eb8b72/sync-files/README.md).

I've tested this locally.