### PR TITLE
Add `topo`

### DIFF
--- a/cspell/.cspell.json
+++ b/cspell/.cspell.json
@@ -140,6 +140,7 @@
         "planing"
     ],
     "words": [
+        "topo",
         "aarch",
         "abspath",
         "abstractmethod",

--- a/cspell/.cspell.json
+++ b/cspell/.cspell.json
@@ -140,7 +140,6 @@
         "planing"
     ],
     "words": [
-        "topo",
         "aarch",
         "abspath",
         "abstractmethod",
@@ -1172,6 +1171,7 @@
         "toolkits",
         "topk",
         "toplevel",
+        "topo",
         "Toprated",
         "tostring",
         "tqdm",


### PR DESCRIPTION
It is used [here](https://github.com/orhun/git-cliff/blob/848d8a587efd5f611a98b647b954c06938fac24a/config/cliff.toml#L58
) and also used like `topo maps`.
https://www.usgs.gov/programs/national-geospatial-program/us-topo-maps-america