### PR TITLE
Add container-related words

### DIFF
--- a/cspell/.cspell.json
+++ b/cspell/.cspell.json
@@ -140,8 +140,6 @@
         "planing"
     ],
     "words": [
-        "prestart",
-        "multiarch",
         "aarch",
         "abspath",
         "abstractmethod",
@@ -773,6 +771,7 @@
         "MSCL",
         "msse",
         "mssql",
+        "multiarch",
         "multilib",
         "multiline",
         "multipass",
@@ -919,6 +918,7 @@
         "prepended",
         "preprocess",
         "preprocessors",
+        "prestart",
         "pretrained",
         "printenv",
         "printf",

--- a/cspell/.cspell.json
+++ b/cspell/.cspell.json
@@ -140,6 +140,8 @@
         "planing"
     ],
     "words": [
+        "prestart",
+        "multiarch",
         "aarch",
         "abspath",
         "abstractmethod",


### PR DESCRIPTION
https://github.com/autowarefoundation/autoware-documentation/runs/5054438985?check_suite_focus=true

`multiarch`: https://wiki.debian.org/Multiarch
`prestart`: a different notation of `pre-start`