### PR TITLE
feat(ignoreRegExpList): ignore GitHub repository patterns

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -154,7 +154,8 @@
     "**/reports*/**"
   ],
   "ignoreRegExpList": [
-    "github.com[/:][\\w._\\-]+(/[\\w._\\-]+)?"
+    "github.com[/:][\\w._\\-]+(/[\\w._\\-]+)?",
+    "\\[.*/.*\\]\\(https://github.com"
   ],
   "flagWords": [
     "planing"

--- a/cspell/.cspell.json
+++ b/cspell/.cspell.json
@@ -154,7 +154,8 @@
     "**/reports*/**"
   ],
   "ignoreRegExpList": [
-    "github.com[/:][\\w._\\-]+(/[\\w._\\-]+)?"
+    "github.com[/:][\\w._\\-]+(/[\\w._\\-]+)?",
+    "\\[.*/.*\\]\\(https://github.com"
   ],
   "flagWords": [
     "planing"


### PR DESCRIPTION
For patterns of `[org/repo-name](https://github.com/org/repo-name)`.

https://github.com/autowarefoundation/autoware-github-actions/pull/85/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R17