### PR TITLE
feat(ignoreRegExpList): add CMakeLists.txt

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -10,7 +10,7 @@
   ],
   "overrides": [
     {
-      "filename": "**/{*.cpp,*.hpp,*.py,*.sh,*.xml,*.yaml}",
+      "filename": "**/{*.cpp,*.hpp,*.py,*.sh,*.xml,*.yaml,CMakeLists.txt}",
       "ignoreRegExpList": [
         "Copyright (\\(c\\))?.+$",
         "FIXME( )?\\(.+?\\)",

--- a/cspell/.cspell.json
+++ b/cspell/.cspell.json
@@ -10,7 +10,7 @@
   ],
   "overrides": [
     {
-      "filename": "**/{*.cpp,*.hpp,*.py,*.sh,*.xml,*.yaml}",
+      "filename": "**/{*.cpp,*.hpp,*.py,*.sh,*.xml,*.yaml,CMakeLists.txt}",
       "ignoreRegExpList": [
         "Copyright (\\(c\\))?.+$",
         "FIXME( )?\\(.+?\\)",

--- a/cspell/.cspell.json
+++ b/cspell/.cspell.json
@@ -10,7 +10,7 @@
   ],
   "overrides": [
     {
-      "filename": "**/{*.cpp,*.hpp,*.py,*.sh,*.xml,*.yaml,CMakeLists.txt}",
+      "filename": "**/{*.cpp,*.hpp,*.py,*.sh,*.xml,*.yaml}",
       "ignoreRegExpList": [
         "Copyright (\\(c\\))?.+$",
         "FIXME( )?\\(.+?\\)",


### PR DESCRIPTION
Added `CMakeLists.txt` file to ignore `TODO(username)` style error.
Related: https://github.com/autowarefoundation/autoware.universe/runs/5534066356?check_suite_focus=true#step:3:20