### PR TITLE
ci(sort-cspell-json): fix ref of actions/checkout

### DIFF
--- a/.github/workflows/sort-cspell-json.yaml
+++ b/.github/workflows/sort-cspell-json.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install jq
         run: |


### PR DESCRIPTION
There was an error in this workflow run: https://github.com/tier4/autoware-spell-check-dict/runs/5632005886?check_suite_focus=true

https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

```
    - uses: actions/checkout@v2
      with:
        ref: ${{ github.event.pull_request.head.sha }}
```