### PR TITLE
feat(words): add mkdocstrings

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -828,6 +828,7 @@
     "MITSHM",
     "mkdir",
     "mkdocs",
+    "mkdocstrings",
     "mobilenetv",
     "Mobileye",
     "modeset",


### PR DESCRIPTION
[`mkdocstrings`](https://github.com/mkdocstrings/mkdocstrings) is one of commonly-used Python package.  
It generates API list from docstrings embedded in Python-based source code.

Signed-off-by: Takayuki AKAMINE <takayuki.akamine@tier4.jp>