### PR TITLE
feat: add Robobus/Robotaxi as names of reference designs

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -1095,6 +1095,8 @@
     "rinfo",
     "RMSE",
     "roadmap",
+    "Robobus",
+    "Robotaxi",
     "robotec",
     "roboteq",
     "Roboto",


### PR DESCRIPTION
I added Robobus and Robotaxi which was defined as external names instead of the internal code names of X2 and XX1.
[Slack](https://star4.slack.com/archives/G4YQ61H0F/p1653524227125449?thread_ts=1653383188.520039&cid=G4YQ61H0F)