### PR TITLE
feat(overrides/svg): ignore inkscape patterns

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -80,6 +80,24 @@
       ]
     },
     {
+      "filename": "**/*.svg",
+      "ignoreRegExpList": [
+        "bbox",
+        "bordercolor",
+        "borderopacity",
+        "inkscape",
+        "inkscape:.*=",
+        "namedview",
+        "nodetypes=\".*\"",
+        "pagecolor",
+        "pageshadow",
+        "showgrid",
+        "sodipodi",
+        "tspan",
+        "xlink:href=\"data:image/png;base64,.*\""
+      ]
+    },
+    {
       "filename": "**/*.toml",
       "ignoreRegExpList": [
         "authors = .*?$",


### PR DESCRIPTION
I couldn't find the format spec, but I've tested this with my file.