### PR TITLE
feat(words): add liblttng

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -787,6 +787,7 @@
     "libgoogle",
     "libground",
     "libimage",
+    "liblttng",
     "libmagick",
     "libmosquitto",
     "libmysqlclient",


### PR DESCRIPTION
`liblttng` is regarded as a misspelled words, and  is used in [rosdep](https://github.com/ros/rosdistro/blob/e6c5b8a9f5c58b09434f9de30d8a95add9a7c0cc/rosdep/base.yaml#L3934-L3941).

`liblttng` is currently used in CARET.
https://github.com/tier4/CARET_trace/blob/cac487a8c5e55960ffe5ec93179a7565e13fb62e/CARET_trace/package.xml#L23