### PR TITLE
feat(package.json/ignoreRegExpList): ignore patterns of dependencies

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -138,6 +138,7 @@
     {
       "filename": "**/package.json",
       "ignoreRegExpList": [
+        "\".*\": \".*[0-9]+\\.[0-9]+\\.[0-9]+.*\"",
         "\"author\": .*"
       ]
     },


### PR DESCRIPTION
I've tested the behavior with the following patterns.

```json
    "@tier4/foobar": "^0.1.2",
    "esbuild": "^0.15.3",
```