### PR TITLE
feat: add adapi

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -206,6 +206,7 @@
     "AccelMap",
     "ACCX",
     "Ackermann",
+    "adapi",
     "addf",
     "addstr",
     "adduser",


### PR DESCRIPTION
The word `adapi` is used for packages related to AD API.