### PR TITLE
feat: add machine learning word

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -199,8 +199,6 @@
     "planing"
   ],
   "words": [
-    "maph",
-    "aphs",
     "aarch",
     "abspath",
     "abstractmethod",
@@ -228,6 +226,7 @@
     "antialiasing",
     "antiquewhite",
     "ANYbotics",
+    "aphs",
     "appinfo",
     "apriltag",
     "arange",
@@ -872,6 +871,7 @@
     "mainpage",
     "Makefiles",
     "malloc",
+    "maph",
     "markdownlint",
     "markersize",
     "mathbb",

--- a/.cspell.json
+++ b/.cspell.json
@@ -199,8 +199,8 @@
     "planing"
   ],
   "words": [
-    "mAPH",
-    "APHs",
+    "maph",
+    "aphs",
     "aarch",
     "abspath",
     "abstractmethod",

--- a/.cspell.json
+++ b/.cspell.json
@@ -199,6 +199,8 @@
     "planing"
   ],
   "words": [
+    "mAPH",
+    "APHs",
     "aarch",
     "abspath",
     "abstractmethod",


### PR DESCRIPTION
I added machine learning words used in the package to be released at the end of September 2022.

APH stands for average precision weighted by heading.

maph stands for mean APH
aphs stands for array of APH

It is proposed in the Waymo's dataset and is explained in the following paper.
https://arxiv.org/pdf/2004.08745.pdf

