### PR TITLE
feat(word): add addopts

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -197,6 +197,7 @@
     "planing"
   ],
   "words": [
+    "addopts",
     "aarch",
     "abspath",
     "abstractmethod",

--- a/.cspell.json
+++ b/.cspell.json
@@ -197,7 +197,6 @@
     "planing"
   ],
   "words": [
-    "addopts",
     "aarch",
     "abspath",
     "abstractmethod",
@@ -206,6 +205,7 @@
     "ACCX",
     "Ackermann",
     "addf",
+    "addopts",
     "addstr",
     "adduser",
     "adehome",


### PR DESCRIPTION
Signed-off-by: hsgwa <19860128+hsgwa@users.noreply.github.com>

addopts : https://docs.pytest.org/en/6.2.x/customize.html#tox-ini
  - "addopts" is a keyword used by pytest configuration.

@kenji-miyake Please review it, best.