### PR TITLE
docs: update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,13 @@ v16.13.0
 # Install a spell checker (cspell) using npm
 $ sudo npm install -g cspell
 
+# Install additional dictionaries
+$ npm install -g yarn
+$ yarn global add https://github.com/tier4/cspell-dicts
+
 # Copy the dictionary into your environment
 $ cd /your-project-dir
-$ wget https://raw.githubusercontent.com/tier4/autoware-spell-check-dict/main/.cspell.json
+$ wget -O .cspell.json https://raw.githubusercontent.com/tier4/autoware-spell-check-dict/main/.cspell.json
 
 # Check spelling
 $ cspell /path/to/src/*.cpp /path/to/include/*.hpp


### PR DESCRIPTION
- To avoid creating `.cspell.json.1`, add `-O .cspell.json`.
- To avoid the following error, install https://github.com/tier4/cspell-dicts.

```console
$ cspell lint "**"
Configuration Error: Failed to read config file: "/home/hyt/ros_ws/x2/src/simulator/driving_log_replayer/@tier4/cspell-dicts/cmake/cspell-ext.json"
CSpell: Files checked: 0, Issues found: 0 in 0 files
```