### PR TITLE
fix(svg/ignoreRegExpList): fix the id pattern

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -185,8 +185,7 @@
         "etag=&quot;[a-zA-Z0-9 +-/_]+&quot;",
         "filter=\"[a-zA-Z0-9 +-/_#()]+\"",
         "font-family: .*;",
-        "id=\"[a-zA-Z0-9 +-/_]+\"",
-        "id=&quot;[a-zA-Z0-9 +-/_]+&quot;",
+        "id=[^\\s]+",
         "name=&quot;[^>]+"
       ]
     },


### PR DESCRIPTION
The current setting didn't work with https://github.com/autowarefoundation/autoware.universe/blob/1a5403d564d203d0d2251a3b454e8aa78385cc6d/sensing/pointcloud_preprocessor/docs/image/vector_map_inside_area_filter_overview.svg?short_path=15feb3e.

Without this PR:

```console
❯ cspell ./sensing/pointcloud_preprocessor/docs/image/vector_map_inside_area_filter_overview.svg
1/1 ./sensing/pointcloud_preprocessor/docs/image/vector_map_inside_area_filter_overview.svg 109715.85ms X
/home/kenji/ghq/github.com/autowarefoundation/autoware.universe/sensing/pointcloud_preprocessor/docs/image/vector_map_inside_area_filter_overview.svg:11:387 - Unknown word (UAUEV)
/home/kenji/ghq/github.com/autowarefoundation/autoware.universe/sensing/pointcloud_preprocessor/docs/image/vector_map_inside_area_filter_overview.svg:11:392 - Unknown word (Cphav)
/home/kenji/ghq/github.com/autowarefoundation/autoware.universe/sensing/pointcloud_preprocessor/docs/image/vector_map_inside_area_filter_overview.svg:11:397 - Unknown word (PCCK)
/home/kenji/ghq/github.com/autowarefoundation/autoware.universe/sensing/pointcloud_preprocessor/docs/image/vector_map_inside_area_filter_overview.svg:11:452 - Unknown word (nvfyjpf)
/home/kenji/ghq/github.com/autowarefoundation/autoware.universe/sensing/pointcloud_preprocessor/docs/image/vector_map_inside_area_filter_overview.svg:11:482 - Unknown word (ydsiw)
/home/kenji/ghq/github.com/autowarefoundation/autoware.universe/sensing/pointcloud_preprocessor/docs/image/vector_map_inside_area_filter_overview.svg:11:497 - Unknown word (brfj)
... (Over 200,000 errors)
```

With this PR:

```console
❯ cspell ./sensing/pointcloud_preprocessor/docs/image/vector_map_inside_area_filter_overview.svg
1/1 ./sensing/pointcloud_preprocessor/docs/image/vector_map_inside_area_filter_overview.svg 304.92ms
CSpell: Files checked: 1, Issues found: 0 in 0 files
```