### PR TITLE
feat(ignoreRegExpList): fix PointXYZ patterns

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -42,8 +42,8 @@
   "ignoreRegExpList": [
     "\\[.*/.*\\]\\(https://github.com",
     "github.com[/:][\\w._\\-]+(/[\\w._\\-]+)?",
-    "XYZ[A-Z]+",
-    "ppa:.+/[^\\s]+"
+    "ppa:.+/[^\\s]+",
+    "XYZ[A-Z]+"
   ],
   "import": [
     "@tier4/cspell-dicts/cmake/cspell-ext.json"

--- a/.cspell.json
+++ b/.cspell.json
@@ -42,7 +42,7 @@
   "ignoreRegExpList": [
     "\\[.*/.*\\]\\(https://github.com",
     "github.com[/:][\\w._\\-]+(/[\\w._\\-]+)?",
-    "PointXYZ[A-Z]+",
+    "XYZ[A-Z]+",
     "ppa:.+/[^\\s]+"
   ],
   "import": [


### PR DESCRIPTION
There were several patterns other than `PointXYZ*`.
https://github.com/tier4/autoware-spell-check-dict/pull/410#issuecomment-1322897656