### PR TITLE
feat(ignorePaths): ignore CHANGELOG.rst

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -30,6 +30,7 @@
     "**/.vscode/**",
     "**/__pycache__/**",
     "**/build/**",
+    "**/CHANGELOG.rst",
     "**/CPPLINT.cfg",
     "**/dist/**",
     "**/external/**",


### PR DESCRIPTION
Signed-off-by: Kotaro Yoshimoto <pythagora.yoshimoto@gmail.com>

spell-checking is effective for miss spellings you can fix.
But, CHANGELOG.rst is based on commit messges and  fixing them is  　falsification for history of repository.
(and, some CHANGELOG.rst has many miss spellings. e.g. [this CHANGELOG.rst](https://github.com/autowarefoundation/autoware.universe/blob/main/sensing/geo_pos_conv/CHANGELOG.rst) has 15 cspell errors )

So, I think spell-checking for CHANGELOG.rst is not nessesary.

I welcome comments from other perspectives!