### PR TITLE
feat(ignoreRegExpList): ignore URL encoded characters for svg file

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -91,6 +91,7 @@
     {
       "filename": "**/*.svg",
       "ignoreRegExpList": [
+        "%[2-7][0-9A-F]",
         "bbox",
         "bordercolor",
         "borderopacity",


### PR DESCRIPTION
Signed-off-by: Kotaro Yoshimoto <pythagora.yoshimoto@gmail.com>

This pull request adds an ignore pattern for URL encoded characters that makes many cspell errors in svg files.

the examples of cspell error source and the errors are below

```svg
<span style="color: rgba(0, 0, 0, 0); font-family: monospace; font-size: 0px; text-align: start;">
%3CmxGraphModel%3E%3Croot%3E%3CmxCell%20id%3D%220%22%2F%3E%3CmxCell%20id%3D%221%22%20parent%3D%220%22%2F%3E%3CmxCell%20id%3D%222%22%20value%3D%22attention_range%22%20style%3D%22text%3Bhtml%3D1%3BstrokeColor%3Dnone%3BfillColor%3Dnone%3Balign%3Dcenter%3BverticalAlign%3Dmiddle%3BwhiteSpace%3Dwrap%3Brounded%3D0%3BfontSize%3D20%3BfontStyle%3D2%22%20vertex%3D%221%22%20parent%3D%221%22%3E%3CmxGeometry%20x%3D%22531%22%20y%3D%221610%22%20width%3D%22210%22%20height%3D%2230%22%20as%3D%22geometry%22%2F%3E%3C%2FmxCell%3E%3C%2Froot%3E%3C%2FmxGraphModel%3E
</span>
```
![image](https://user-images.githubusercontent.com/12395284/205617885-5bd4937c-02da-4aa7-a63a-bceaf269cf6b.png)

reference: https://www.seil.jp/doc/index.html#tool/url-encode.html