### PR TITLE
feat(languageSettings/dockerfile): ignore the `FROM` pattern

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -51,6 +51,12 @@
   ],
   "languageSettings": [
     {
+      "languageId": "dockerfile",
+      "ignoreRegExpList": [
+        "^FROM .*?\\s"
+      ]
+    },
+    {
       "languageId": "markdown",
       "dictionaries": [
         "latex"


### PR DESCRIPTION
To support the patterns like https://github.com/tier4/perception_ecu_container/blob/616918635ab33cf0c003c21a4dec499217f9457e/docker/Dockerfile#L6.

Related: https://github.com/tier4/autoware-spell-check-dict/pull/431