### PR TITLE
feat(svg/ignoreRegExpList): add words

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -111,6 +111,8 @@
         "inkscape:.*=",
         "Josefin",
         "mathml",
+        "merror",
+        "mfrac",
         "mlabeledtr",
         "mrow",
         "MSIE",

--- a/.cspell.json
+++ b/.cspell.json
@@ -213,7 +213,7 @@
         "@author .*$",
         "\\author .*$",
         "Author(s)?( )?: .*$",
-        "trapam"
+        "tparam"
       ]
     },
     {

--- a/.cspell.json
+++ b/.cspell.json
@@ -114,6 +114,7 @@
         "MSIE",
         "mstyle",
         "msub",
+        "mtext",
         "namedview",
         "neue",
         "nodetypes=\".*\"",

--- a/.cspell.json
+++ b/.cspell.json
@@ -114,6 +114,7 @@
         "merror",
         "mfrac",
         "mlabeledtr",
+        "mphantom",
         "mrow",
         "MSIE",
         "mstyle",

--- a/.cspell.json
+++ b/.cspell.json
@@ -115,6 +115,7 @@
         "MSIE",
         "mstyle",
         "msub",
+        "mtable",
         "mtext",
         "munder",
         "munderover",

--- a/.cspell.json
+++ b/.cspell.json
@@ -119,6 +119,7 @@
         "MSIE",
         "mstyle",
         "msub",
+        "msup",
         "mtable",
         "mtext",
         "munder",

--- a/.cspell.json
+++ b/.cspell.json
@@ -103,6 +103,7 @@
         "bbox",
         "bordercolor",
         "borderopacity",
+        "darkreader",
         "displaystyle",
         "dropshadow",
         "focusable",

--- a/.cspell.json
+++ b/.cspell.json
@@ -116,6 +116,7 @@
         "mstyle",
         "msub",
         "mtext",
+        "munder",
         "namedview",
         "neue",
         "nodetypes=\".*\"",

--- a/.cspell.json
+++ b/.cspell.json
@@ -117,6 +117,7 @@
         "msub",
         "mtext",
         "munder",
+        "munderover",
         "namedview",
         "neue",
         "nodetypes=\".*\"",

--- a/.cspell.json
+++ b/.cspell.json
@@ -108,6 +108,7 @@
         "focusable",
         "inkscape",
         "inkscape:.*=",
+        "Josefin",
         "mathml",
         "mrow",
         "MSIE",

--- a/.cspell.json
+++ b/.cspell.json
@@ -111,6 +111,7 @@
         "inkscape:.*=",
         "Josefin",
         "mathml",
+        "mlabeledtr",
         "mrow",
         "MSIE",
         "mstyle",


### PR DESCRIPTION
| word | target | |
| --- | --- | --- |
| Josefin | svg | part of "Josefin Sans", a font name |
| mtext | svg | https://developer.mozilla.org/en-US/docs/Web/MathML/Element/mtext |
| munder | svg | https://developer.mozilla.org/en-US/docs/Web/MathML/Element/munder |
| munderover | svg | https://developer.mozilla.org/en-US/docs/Web/MathML/Element/munderover |
| mtable | svg | https://developer.mozilla.org/en-US/docs/Web/MathML/Element/mtable |
| mlabeledtr | svg | https://udn.realityripple.com/docs/Web/MathML/Element/mlabeledtr |
| mfrac | svg | https://developer.mozilla.org/en-US/docs/Web/MathML/Element/mfrac |
| mphantom | svg | https://developer.mozilla.org/en-US/docs/Web/MathML/Element/mphantom |
| msup | svg | https://developer.mozilla.org/en-US/docs/Web/MathML/Element/msup |