### PR TITLE
refactor: avoid matching SetParameter

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -211,9 +211,9 @@
       "filename": "**/{*.cpp,*.hpp}",
       "ignoreRegExpList": [
         "@author .*$",
+        "[\\@]tparam",
         "\\author .*$",
-        "Author(s)?( )?: .*$",
-        "[\\@]tparam"
+        "Author(s)?( )?: .*$"
       ]
     },
     {

--- a/.cspell.json
+++ b/.cspell.json
@@ -213,7 +213,7 @@
         "@author .*$",
         "\\author .*$",
         "Author(s)?( )?: .*$",
-        "tparam"
+        "[\\@]tparam"
       ]
     },
     {


### PR DESCRIPTION
Avoid matching `tparam` in `SetParameter`