### PR TITLE
feat(ignoreRegExpList): ignore copyright patterns

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -42,6 +42,7 @@
   ],
   "ignoreRegExpList": [
     "\\[.*/.*\\]\\(https://github.com",
+    "Copyright .*[0-9]{4}.+",
     "github.com[/:][\\w._\\-]+(/[\\w._\\-]+)?",
     "ppa:.+/[^\\s]+",
     "XYZ[A-Z]+"


### PR DESCRIPTION
Copyrights usually contain proper noun, which often causes false positives.
Example: https://github.com/tier4/CalibrationTools/blob/3ac4928e705e652ff114ea48a4dba046ff622ce0/sensor/docs/resource/KALIBR_LICENSE