### PR TITLE
feat(flagWords): add incorrect patterns of `TIER IV`

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -248,9 +248,9 @@
     "JIRA",
     "planing",
     "ROS2",
-    "TIERIV",
-    "TierIV",
     "Tier4",
+    "TierIV",
+    "TIERIV",
     "VSCode"
   ],
   "words": [

--- a/.cspell.json
+++ b/.cspell.json
@@ -248,6 +248,9 @@
     "JIRA",
     "planing",
     "ROS2",
+    "TIERIV",
+    "TierIV",
+    "Tier4",
     "VSCode"
   ],
   "words": [

--- a/.cspell.json
+++ b/.cspell.json
@@ -249,8 +249,8 @@
     "planing",
     "ROS2",
     "Tier4",
-    "TierIV",
     "TIERIV",
+    "TierIV",
     "VSCode"
   ],
   "words": [


### PR DESCRIPTION
https://tier4.jp/en/media/detail/?sys_id=4nwhhCgZGuFnqt9MuveSzp&category=DOCUMENTS

We must use `TIER IV` or `tier4` (allowed in URLs).