### PR TITLE
ci(format_cspell_json): fix sorting

### DIFF
--- a/format_cspell_json/format_cspell_json.py
+++ b/format_cspell_json/format_cspell_json.py
@@ -30,7 +30,7 @@ def format_json_recursive(j: Dict) -> Dict:
             j = [format_json_recursive(v) for v in j]
         else:
             j = list(set(j))
-            j = sorted(j, key=str.lower)
+            j = sorted(j, key=lambda s: (str.casefold(s), s))
     return j
 
 


### PR DESCRIPTION
To prevent `TierIV` and `TIERIV` from always swapping.
![image](https://user-images.githubusercontent.com/31987104/232269697-c8a3b4f8-c568-4ada-96e4-6c87f4cc52e1.png)

The key is from https://github.com/tier4/cspell-dicts/blob/3023f03f46209f4adaf179d71185b2289ceb9346/tier4_cspell_dicts/format_words.py#L11.