### PR TITLE
feat(svg/ignoreRegExpList): ignore fill

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -110,6 +110,7 @@
         "darkreader",
         "displaystyle",
         "dropshadow",
+        "fill=\".*\"",
         "focusable",
         "inkscape",
         "inkscape:.*=",


### PR DESCRIPTION
Found in https://github.com/autowarefoundation/autoware-documentation/pull/367/files.

![image](https://github.com/tier4/autoware-spell-check-dict/assets/31987104/afcc7592-8faf-4de3-8944-d1ab0166e895)
