### PR TITLE
feat: add truetype for svg

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -232,11 +232,11 @@
         "filter=\"[a-zA-Z0-9 +-/_#()]+\"",
         "font-family: .*;",
         "freesans",
-        "truetype",
         "host=&quot;[a-zA-Z0-9 +-/_]+&quot;",
         "id=[^\\s]+",
         "name=&quot;[^>]+",
-        "segoe"
+        "segoe",
+        "truetype"
       ]
     },
     {

--- a/.cspell.json
+++ b/.cspell.json
@@ -232,6 +232,7 @@
         "filter=\"[a-zA-Z0-9 +-/_#()]+\"",
         "font-family: .*;",
         "freesans",
+        "truetype",
         "host=&quot;[a-zA-Z0-9 +-/_]+&quot;",
         "id=[^\\s]+",
         "name=&quot;[^>]+",


### PR DESCRIPTION
Some svg files include a word "truetype" to identify the font name [TrueType](https://en.wikipedia.org/wiki/TrueType).