### PR TITLE
feat(words): add mathvariant for svg

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -236,7 +236,8 @@
         "id=[^\\s]+",
         "name=&quot;[^>]+",
         "segoe",
-        "truetype"
+        "truetype",
+        "mathvariant"
       ]
     },
     {

--- a/.cspell.json
+++ b/.cspell.json
@@ -234,10 +234,10 @@
         "freesans",
         "host=&quot;[a-zA-Z0-9 +-/_]+&quot;",
         "id=[^\\s]+",
+        "mathvariant",
         "name=&quot;[^>]+",
         "segoe",
-        "truetype",
-        "mathvariant"
+        "truetype"
       ]
     },
     {


### PR DESCRIPTION
word of [mathvariant](https://developer.mozilla.org/en-US/docs/Web/MathML/Global_attributes/mathvariant) is included in svg file.
mathvariant is the attribute that determines the style for a mathematical expression.