### PR TITLE
feat(words): added Heisai

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -788,6 +788,7 @@
     "Headerless",
     "heaphook",
     "heatmaps",
+    "Heisai",
     "Heisenbug",
     "Heisenbugs",
     "hexdigest",


### PR DESCRIPTION
Added Heisai, the CI for Nebula fails because of it (https://github.com/tier4/nebula/actions/runs/5998449271/job/16266747381?pr=59)