### PR TITLE
fix(words): remove flag word "Github"

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -761,7 +761,6 @@
     "GICP",
     "giga",
     "giou",
-    "Github",
     "glasbey",
     "GLIBCXX",
     "glog",


### PR DESCRIPTION
Reverts tier4/autoware-spell-check-dict#682
Because it's flag word.
https://github.com/tier4/autoware-spell-check-dict/blob/main/.cspell.json#L256