### PR TITLE
feat(words): add words lidarmarker

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -1005,6 +1005,7 @@
     "libvulkan",
     "libxft",
     "libzmqpp",
+    "lidarmarker",
     "lidars",
     "lidartag",
     "light",
@@ -1877,7 +1878,6 @@
     "zmqpp",
     "zorder",
     "zstd",
-    "zsync",
-    "lidarmarker"
+    "zsync"
   ]
 }

--- a/.cspell.json
+++ b/.cspell.json
@@ -1877,6 +1877,7 @@
     "zmqpp",
     "zorder",
     "zstd",
-    "zsync"
+    "zsync",
+    "lidarmarker"
   ]
 }


### PR DESCRIPTION
add words for https://github.com/autowarefoundation/autoware.universe/pull/5573
`lidarmarker` is a combination of the words "lidar" and "marker".