### PR TITLE
fix: add adkit to .cspell.json

### DIFF
--- a/cspell/.cspell.json
+++ b/cspell/.cspell.json
@@ -168,6 +168,7 @@
     "adduser",
     "adehome",
     "aderc",
+    "adkit",
     "adoc",
     "AHCI",
     "aliceblue",


### PR DESCRIPTION
Fixes https://github.com/autowarefoundation/autoware/actions/runs/9091082555/job/24985001467?pr=4721

https://autoware.org/open-ad-kit/