### PR TITLE
fix: add buildcache to .cspell.json

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -406,6 +406,7 @@
     "bson",
     "bugprone",
     "bugtracker",
+    "buildcache",
     "BUILDKIT",
     "buildtool",
     "buildx",


### PR DESCRIPTION
Fixed https://github.com/autowarefoundation/autoware/actions/runs/9091082555/job/24985001467?pr=4721

https://docs.docker.com/build/cache/