### PR TITLE
fix: add adkit to .cspell.json

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -281,6 +281,7 @@
     "adehome",
     "aderc",
     "adjacents",
+    "adkit",
     "ADMM",
     "adoc",
     "AHCI",


### PR DESCRIPTION
Fixed https://github.com/autowarefoundation/autoware/actions/runs/9091082555/job/24985001467?pr=4721

https://autoware.org/open-ad-kit/