### PR TITLE
docs: add notation in pull-request template

### DIFF
--- a/.github/workflows/add-word.yaml
+++ b/.github/workflows/add-word.yaml
@@ -44,7 +44,9 @@ jobs:
           commit-message: "feat(words): add ${{ inputs.word }}"
           body: |
             TODO: Update this comment and add some reference links.
-            Please check [CONTRIBUTING.md](https://github.com/tier4/autoware-spell-check-dict/blob/main/CONTRIBUTING.md) before sending PR.
+            > [!NOTE]
+            > To get approval, you need to show external documentation proving that the word is not your own creation, but is common in the public and industry.
+            > Please check [CONTRIBUTING.md](https://github.com/tier4/autoware-spell-check-dict/blob/main/CONTRIBUTING.md) for detail.
           labels: |
             bot
             words

--- a/.github/workflows/add-word.yaml
+++ b/.github/workflows/add-word.yaml
@@ -44,6 +44,9 @@ jobs:
           commit-message: "feat(words): add ${{ inputs.word }}"
           body: |
             TODO: Update this comment and add some reference links.
+            your usage of the word: [link of github or something]()
+            The documentation for the word: [link for word documentation]()
+            
             > [!NOTE]
             > To get approval, you need to show external documentation proving that the word is not your own creation, but is common in the public and industry.
             > Please check [CONTRIBUTING.md](https://github.com/tier4/autoware-spell-check-dict/blob/main/CONTRIBUTING.md) for detail.

--- a/.github/workflows/add-word.yaml
+++ b/.github/workflows/add-word.yaml
@@ -46,7 +46,7 @@ jobs:
             TODO: Update this comment and add some reference links.
             your usage of the word: [link of github or something]()
             The documentation for the word: [link for word documentation]()
-            
+
             > [!NOTE]
             > To get approval, you need to show external documentation proving that the word is not your own creation, but is common in the public and industry.
             > Please check [CONTRIBUTING.md](https://github.com/tier4/autoware-spell-check-dict/blob/main/CONTRIBUTING.md) for detail.


### PR DESCRIPTION
Since not a few people submit PRs by providing only a link with their own usage only, I decided to add a notation to the PR template like below

---
TODO: Update this comment and add some reference links.
your usage of the word: [link of github or something]()
The documentation for the word: [link for word documentation]()

> [!NOTE]
> To get approval, you need to show external documentation proving that the word is not your own creation, but is common in the public and industry.
> Please check [CONTRIBUTING.md](https://github.com/tier4/autoware-spell-check-dict/blob/main/CONTRIBUTING.md) for detail.